### PR TITLE
Bug Fixed

### DIFF
--- a/src/enzo/Grid_ConvertToLibyt.C
+++ b/src/enzo/Grid_ConvertToLibyt.C
@@ -51,7 +51,7 @@ void grid::ConvertToLibyt(int LocalGridID, int GlobalGridID, int ParentID, int l
      * */
   
     for (int i = 0; i < MAX_DIMENSION; i++) {
-        GridInfo.grid_dimensions[i] = this->GridDimension[i];
+        GridInfo.grid_dimensions[i] = (this->GridEndIndex[i]) - (this->GridStartIndex[i]) + 1; // this is active dimension
         GridInfo.left_edge[i] = this->GridLeftEdge[i];
         GridInfo.right_edge[i] = this->GridRightEdge[i];
     }


### PR DESCRIPTION
### Fix the Bug

`grid_dimensions` defined in libyt is active dimensions in Enzo.
libyt and post-processing generate the same output figure under the same time stamps.
I use `SlicePlot` and `ProjectionPlot` for test.

### TODO
- [ ] Another thing needs to consider is where to put the `CallInSituLibyt` function. I put it inside `EvolveLevel`. And this is bad, since the frequency of calling libyt is too high. Do you have any suggestions?