### PR TITLE
Initialize Doc for Enzo and Merge Headers

### DIFF
--- a/doc/manual/source/supplementary_info/PythonInSituAnalysis.rst
+++ b/doc/manual/source/supplementary_info/PythonInSituAnalysis.rst
@@ -1,0 +1,24 @@
+.. _embedded-python:
+
+Python In Situ Analysis
+=======================
+
+
+How To Compile
+--------------
+
+
+
+How it Works
+------------
+
+
+How to Run
+----------
+
+
+Which Operations Work
+---------------------
+
+
+

--- a/src/enzo/CallEmptyInteractivePython.C
+++ b/src/enzo/CallEmptyInteractivePython.C
@@ -14,7 +14,6 @@
 
 #ifdef USE_LIBYT
 #include "libyt.h"
-#include "libyt_interactive_mode.h"
 #endif
 
 #include <stdlib.h>

--- a/src/enzo/CallEmptyInteractivePython.C
+++ b/src/enzo/CallEmptyInteractivePython.C
@@ -13,8 +13,8 @@
 ************************************************************************/
 
 #ifdef USE_LIBYT
-#include "libyt/libyt.h"
-#include "libyt/libyt_interactive_mode.h"
+#include "libyt.h"
+#include "libyt_interactive_mode.h"
 #endif
 
 #include <stdlib.h>

--- a/src/enzo/CallInSitulibyt.C
+++ b/src/enzo/CallInSitulibyt.C
@@ -14,7 +14,6 @@
 
 #ifdef USE_LIBYT
 #include "libyt.h"
-#include "libyt_interactive_mode.h"
 #endif
 
 #include <stdlib.h>

--- a/src/enzo/CallInSitulibyt.C
+++ b/src/enzo/CallInSitulibyt.C
@@ -13,8 +13,8 @@
 ************************************************************************/
 
 #ifdef USE_LIBYT
-#include "libyt/libyt.h"
-#include "libyt/libyt_interactive_mode.h"
+#include "libyt.h"
+#include "libyt_interactive_mode.h"
 #endif
 
 #include <stdlib.h>

--- a/src/enzo/ExposeHierarchyToLibyt.C
+++ b/src/enzo/ExposeHierarchyToLibyt.C
@@ -12,10 +12,10 @@
 
 // This function writes out the data hierarchy (TopGrid)
 #ifdef USE_LIBYT
-#include "libyt/libyt.h"
+#include "libyt.h"
 #endif
 
-#include "libyt/libyt.h"
+#include "libyt.h"
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>

--- a/src/enzo/Grid_ConvertToLibyt.C
+++ b/src/enzo/Grid_ConvertToLibyt.C
@@ -18,7 +18,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
-#include "libyt/libyt.h"
+#include "libyt.h"
 #include "ErrorExceptions.h"
 #include "macros_and_parameters.h"
 #include "typedefs.h"

--- a/src/enzo/InitializeLibytInterface.C
+++ b/src/enzo/InitializeLibytInterface.C
@@ -14,7 +14,6 @@
 ************************************************************************/
 
 #include "libyt.h"
-#include "libyt_interactive_mode.h"
 
 // We do this before any Enzo includes
 

--- a/src/enzo/InitializeLibytInterface.C
+++ b/src/enzo/InitializeLibytInterface.C
@@ -13,8 +13,8 @@
 /
 ************************************************************************/
 
-#include "libyt/libyt.h"
-#include "libyt/libyt_interactive_mode.h"
+#include "libyt.h"
+#include "libyt_interactive_mode.h"
 
 // We do this before any Enzo includes
 


### PR DESCRIPTION
## Initialize Doc for Enzo and Merge Headers
- Make `libyt_interactive_mode.h` live inside `libyt.h`.
- Initialize documents for libyt for Enzo in `doc/manual/source/supplementary_info/PythonInSituAnalysis.rst`. The settings is not correct, since I don't know how to use rst.