### PR TITLE
Merge Enzo main and make sure it works with libyt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,7 +240,7 @@ jobs:
 
   test-compile-options:
     docker:
-      - image: cimg/python:3.11.5
+      - image: cimg/python:3.10.13
 
     resource_class: large
     working_directory: ~/enzo-dev
@@ -271,7 +271,7 @@ jobs:
 
   docs-build:
     docker:
-      - image: cimg/python:3.11.5
+      - image: cimg/python:3.10.13
 
     working_directory: ~/enzo-dev
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,7 +217,7 @@ jobs:
 
       - restore_cache:
           name: "Restore test answers."
-          key: test-answers-v16b
+          key: test-answers-v16a
 
       - build-and-test:
           tag: gold-standard-v16
@@ -226,7 +226,7 @@ jobs:
 
       - save_cache:
           name: "Save test answers cache."
-          key: test-answers-v16b
+          key: test-answers-v16a
           paths:
             - ~/enzo_test/push_suite
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,13 +200,13 @@ jobs:
 
       - restore_cache:
           name: "Restore dependencies cache."
-          key: dependencies-v3
+          key: dependencies-v4
 
       - install-dependencies
 
       - save_cache:
           name: "Save dependencies cache"
-          key: dependencies-v3
+          key: dependencies-v4
           paths:
             - ~/.cache/pip
             - ~/venv
@@ -251,13 +251,13 @@ jobs:
 
       - restore_cache:
           name: "Restore dependencies cache."
-          key: dependencies-v3
+          key: dependencies-v4
 
       - install-dependencies
 
       - save_cache:
           name: "Save dependencies cache"
-          key: dependencies-v3
+          key: dependencies-v4
           paths:
             - ~/.cache/pip
             - ~/venv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,7 +189,7 @@ commands:
 jobs:
   test-suite:
     docker:
-      - image: cimg/python:3.11.5
+      - image: cimg/python:3.10.13
 
     resource_class: large
     working_directory: ~/enzo-dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,16 +217,16 @@ jobs:
 
       - restore_cache:
           name: "Restore test answers."
-          key: test-answers-v15a
+          key: test-answers-v16a
 
       - build-and-test:
-          tag: gold-standard-v15
+          tag: gold-standard-v16
           skipfile: ~/enzo_test/push_suite
           flags: --answer-store
 
       - save_cache:
           name: "Save test answers cache."
-          key: test-answers-v15a
+          key: test-answers-v16a
           paths:
             - ~/enzo_test/push_suite
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,7 +217,7 @@ jobs:
 
       - restore_cache:
           name: "Restore test answers."
-          key: test-answers-v16b
+          key: test-answers-v16c
 
       - build-and-test:
           tag: gold-standard-v16
@@ -226,7 +226,7 @@ jobs:
 
       - save_cache:
           name: "Save test answers cache."
-          key: test-answers-v16b
+          key: test-answers-v16c
           paths:
             - ~/enzo_test/push_suite
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ commands:
             source $BASH_ENV
             sudo apt-get update
             sudo apt-get install -y csh libhdf5-serial-dev libopenmpi-dev openmpi-bin gfortran libtool-bin xutils-dev
-            python -m venv $HOME/venv
+            python3 -m venv $HOME/venv
             source $HOME/venv/bin/activate
             pip install --upgrade pip
             pip install --upgrade wheel
@@ -76,7 +76,7 @@ commands:
           command: |
             sudo apt-get update
             sudo apt-get install -y dvipng texlive-latex-extra
-            python -m venv $HOME/venv
+            python3 venv $HOME/venv
             source $HOME/venv/bin/activate
             pip install --upgrade pip
             pip install --upgrade wheel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ commands:
           command: |
             sudo apt-get update
             sudo apt-get install -y dvipng texlive-latex-extra
-            python3 venv $HOME/venv
+            python3 -m venv $HOME/venv
             source $HOME/venv/bin/activate
             pip install --upgrade pip
             pip install --upgrade wheel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ commands:
             pip install --upgrade pip
             pip install --upgrade wheel
             pip install --upgrade setuptools
-            pip install Cython numpy h5py fastcache flake8 nose girder-client matplotlib pytest gitpython # yt
+            pip install Cython numpy h5py fastcache flake8 nose3 girder-client matplotlib pytest gitpython # yt
             # Temporary workaround to use updated answer testing from the yt dev repository
             # instead of pip until next yt point release
             git clone https://github.com/yt-project/yt
@@ -189,7 +189,7 @@ commands:
 jobs:
   test-suite:
     docker:
-      - image: cimg/python:3.11.5
+      - image: cimg/python:3.10.10
 
     resource_class: large
     working_directory: ~/enzo-dev
@@ -240,7 +240,7 @@ jobs:
 
   test-compile-options:
     docker:
-      - image: cimg/python:3.11.5
+      - image: cimg/python:3.10.10
 
     resource_class: large
     working_directory: ~/enzo-dev
@@ -271,7 +271,7 @@ jobs:
 
   docs-build:
     docker:
-      - image: cimg/python:3.11.5
+      - image: cimg/python:3.10.10
 
     working_directory: ~/enzo-dev
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ commands:
             source $BASH_ENV
             sudo apt-get update
             sudo apt-get install -y csh libhdf5-serial-dev libopenmpi-dev openmpi-bin gfortran libtool-bin xutils-dev
-            python3 -m venv $HOME/venv
+            python -m venv $HOME/venv
             source $HOME/venv/bin/activate
             pip install --upgrade pip
             pip install --upgrade wheel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,7 +189,7 @@ commands:
 jobs:
   test-suite:
     docker:
-      - image: cimg/python:3.8.5
+      - image: cimg/python:3.11.5
 
     resource_class: large
     working_directory: ~/enzo-dev
@@ -237,7 +237,7 @@ jobs:
 
   test-compile-options:
     docker:
-      - image: cimg/python:3.8.5
+      - image: cimg/python:3.11.5
 
     resource_class: large
     working_directory: ~/enzo-dev
@@ -268,7 +268,7 @@ jobs:
 
   docs-build:
     docker:
-      - image: cimg/python:3.8.5
+      - image: cimg/python:3.11.5
 
     working_directory: ~/enzo-dev
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,7 +217,7 @@ jobs:
 
       - restore_cache:
           name: "Restore test answers."
-          key: test-answers-v16a
+          key: test-answers-16
 
       - build-and-test:
           tag: gold-standard-v16
@@ -226,7 +226,7 @@ jobs:
 
       - save_cache:
           name: "Save test answers cache."
-          key: test-answers-v16a
+          key: test-answers-v16
           paths:
             - ~/enzo_test/push_suite
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,7 +217,7 @@ jobs:
 
       - restore_cache:
           name: "Restore test answers."
-          key: test-answers-v16
+          key: test-answers-v16b
 
       - build-and-test:
           tag: gold-standard-v16
@@ -226,7 +226,7 @@ jobs:
 
       - save_cache:
           name: "Save test answers cache."
-          key: test-answers-v16
+          key: test-answers-v16b
           paths:
             - ~/enzo_test/push_suite
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ commands:
             source $BASH_ENV
             sudo apt-get update
             sudo apt-get install -y csh libhdf5-serial-dev libopenmpi-dev openmpi-bin gfortran libtool-bin xutils-dev
-            python3 -m venv $HOME/venv
+            python -m venv $HOME/venv
             source $HOME/venv/bin/activate
             pip install --upgrade pip
             pip install --upgrade wheel
@@ -76,7 +76,7 @@ commands:
           command: |
             sudo apt-get update
             sudo apt-get install -y dvipng texlive-latex-extra
-            python3 -m venv $HOME/venv
+            python -m venv $HOME/venv
             source $HOME/venv/bin/activate
             pip install --upgrade pip
             pip install --upgrade wheel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,6 +235,9 @@ jobs:
           skipfile: notafile
           flags: --clobber
 
+      - store_artifacts:
+          path: ~/enzo-dev/src/enzo/out.compile
+
   test-compile-options:
     docker:
       - image: cimg/python:3.11.5

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ commands:
             source $BASH_ENV
             sudo apt-get update
             sudo apt-get install -y csh libhdf5-serial-dev libopenmpi-dev openmpi-bin gfortran libtool-bin xutils-dev
-            python -m venv $HOME/venv
+            python3 -m venv $HOME/venv
             source $HOME/venv/bin/activate
             pip install --upgrade pip
             pip install --upgrade wheel
@@ -189,7 +189,7 @@ commands:
 jobs:
   test-suite:
     docker:
-      - image: cimg/python:3.10.13
+      - image: cimg/python:3.11.5
 
     resource_class: large
     working_directory: ~/enzo-dev
@@ -240,7 +240,7 @@ jobs:
 
   test-compile-options:
     docker:
-      - image: cimg/python:3.10.13
+      - image: cimg/python:3.11.5
 
     resource_class: large
     working_directory: ~/enzo-dev
@@ -271,7 +271,7 @@ jobs:
 
   docs-build:
     docker:
-      - image: cimg/python:3.10.13
+      - image: cimg/python:3.11.5
 
     working_directory: ~/enzo-dev
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,7 +189,7 @@ commands:
 jobs:
   test-suite:
     docker:
-      - image: cimg/python:3.10.10
+      - image: cimg/python:3.10
 
     resource_class: large
     working_directory: ~/enzo-dev
@@ -200,13 +200,13 @@ jobs:
 
       - restore_cache:
           name: "Restore dependencies cache."
-          key: dependencies-v4
+          key: dependencies-v5
 
       - install-dependencies
 
       - save_cache:
           name: "Save dependencies cache"
-          key: dependencies-v4
+          key: dependencies-v5
           paths:
             - ~/.cache/pip
             - ~/venv
@@ -240,7 +240,7 @@ jobs:
 
   test-compile-options:
     docker:
-      - image: cimg/python:3.10.10
+      - image: cimg/python:3.10
 
     resource_class: large
     working_directory: ~/enzo-dev
@@ -251,13 +251,13 @@ jobs:
 
       - restore_cache:
           name: "Restore dependencies cache."
-          key: dependencies-v4
+          key: dependencies-v5
 
       - install-dependencies
 
       - save_cache:
           name: "Save dependencies cache"
-          key: dependencies-v4
+          key: dependencies-v5
           paths:
             - ~/.cache/pip
             - ~/venv
@@ -271,7 +271,7 @@ jobs:
 
   docs-build:
     docker:
-      - image: cimg/python:3.10.10
+      - image: cimg/python:3.10
 
     working_directory: ~/enzo-dev
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,7 +217,7 @@ jobs:
 
       - restore_cache:
           name: "Restore test answers."
-          key: test-answers-16
+          key: test-answers-v16
 
       - build-and-test:
           tag: gold-standard-v16

--- a/doc/manual/source/parameters/index.rst
+++ b/doc/manual/source/parameters/index.rst
@@ -2266,6 +2266,12 @@ The parameters below are considered in ``StarParticleCreation`` method
     the particle creation time by this amount.  This value is in units of Myrs.  If set
     to a negative value, energy, mass and metals are injected gradually in the same way as is
     done for ``StarParticleFeedback`` method = 1.  Default -1.
+``StarFormationOncePerRootGridTimeStep`` (external)
+    Only valid for ``StarParticleFeedback`` methods 1 and 11. Star formation will only
+    occur at the beginning of the root grid step and with a mass proportional to the root grid timestep.
+    Stars can still only form on the most refined grid in a given volume. This option
+    results in fewer, more massive star particles.
+    Default: 0 (off)
 ``StarMakerMinimumMassRamp`` (external)
      Sets the Minimum Stellar Mass (otherwise given by ``StarMakerMinimumMass`` to 
      ramp up over time, so that a small mass can be used early in the calculation
@@ -2353,8 +2359,6 @@ The parameters below are considered in ``StarParticleCreation`` method 11.
 ``H2StarMakerH2FloorInColdGas`` (external)
     See :ref:`molecular_hydrogen_regulated_star_formation`.
 ``H2StarMakerColdGasTemperature`` (external)
-    See :ref:`molecular_hydrogen_regulated_star_formation`.
-``StarFormationOncePerRootGridTimeStep`` (external)
     See :ref:`molecular_hydrogen_regulated_star_formation`.
 
 .. _popIII_star_formation_parameters:

--- a/doc/manual/source/physics/star_particles.rst
+++ b/doc/manual/source/physics/star_particles.rst
@@ -441,10 +441,11 @@ applied, below which no star formation occurs.
 
 Typically this method is used with
 ``StarFormationOncePerRootGridTimeStep``, in which case SF occurs only
-at the beginning of the root grid step and only for grids on
-MaximumRefinementLevel, but with a star particle mass that is
+at the beginning of the root grid step and with a star particle mass that is
 proportial to the root grid time step (as opposed to the much smaller
-time step of the maximally refined grid). This results in fewer and
+time step of the maximally refined grid). Star particles will still only
+form on the most refined grid in a given region.
+This results in fewer and
 more massive star particles, which improves computational
 efficiency. Even so, it may be desirable to enforce a lower limit to
 the star particle mass in some cases. This can be done with the

--- a/input/gen_equilibrium_table.py
+++ b/input/gen_equilibrium_table.py
@@ -8,7 +8,7 @@
 # As is, this script makes a table spanning 1e-29 to 1e-23 g/cm^3
 # and 1e4 to 1e6 K using 50 cells on a side. The constant metallicity is 
 # 0.27 Zsun and the HM2012 UV background is used. The table is calculated for
-# redshift 0. The table size and are included in the resulting HDF5 filename.
+# redshift 0. The table size and metallicity are included in the resulting HDF5 filename.
 #
 ###############################################################################
 
@@ -19,18 +19,22 @@ from pygrackle import \
     chemistry_data, \
     setup_fluid_container
 from pygrackle.utilities.physical_constants import \
+	cm_per_mpc as Mpc, \
+	amu_cgs as m_u, \
+	mass_sun_cgs as Msun, \
+	keV_per_K as kboltz, \
 	sec_per_Myr, \
 	cm_per_kpc
 
-size_1d = 50 # square table; length of each side
-z = 0.27 # solar units
+# 1e-29 to 1e-23 g/cm**3
+# 6.5e4 to 1.5e6 K
 
-# Table's density & temperature grid is in log space
-dens = np.logspace(-29, -23, size_1d) # cgs
-temp = np.logspace(4, 6, size_1d) # K
+size_1d = 60 # square table; length of each side
+Z = 0.3 # solar units
+
+dens = np.logspace(np.log10(1e-31), np.log10(1e-23), size_1d) # cgs
+temp = np.logspace(np.log10(3e3), np.log10(3e6), size_1d) # K
 d, t = np.meshgrid(dens, temp)
-
-current_redshift = 0.
 
 # Set solver parameters
 chem = chemistry_data()
@@ -40,8 +44,7 @@ chem.primordial_chemistry = 2
 chem.metal_cooling = 1
 chem.UVbackground = 1
 chem.cmb_temperature_floor = 1
-chem.h2_on_dust = 1
-chem.grackle_data_file = "/PATH/TO/GRACKLE/input/CloudyData_UVB=HM2012.h5"
+chem.grackle_data_file = b"/PATH/TO/GRACKLE/input/CloudyData_UVB=HM2012.h5"
 
 chem.use_specific_heating_rate = 0
 chem.use_volumetric_heating_rate = 0
@@ -49,7 +52,7 @@ chem.use_volumetric_heating_rate = 0
 # Set units
 chem.comoving_coordinates = 0 # proper units
 chem.a_units = 1.0
-chem.a_value = 1.0 / (1.0 + current_redshift) / chem.a_units
+chem.a_value = 1.0
 chem.density_units = 1.67e-27
 chem.length_units = 1638.4 * cm_per_kpc
 chem.time_units = sec_per_Myr
@@ -60,22 +63,24 @@ chem.velocity_units = chem.a_units \
 # Call convenience function for setting up a fluid container.
 # This container holds the solver parameters, units, and fields.
 fc = setup_fluid_container(chem,
-                           density=d.flatten(),
-                           temperature=t.flatten(),
-                           metal_mass_fraction=0.02014*z,
-                           converge=True)
+                           density=d.ravel(),
+                           temperature=t.ravel(),
+                           metal_mass_fraction=0.01295*Z,
+                           converge=True,
+                           tolerance=1e-7, # default: 0.01
+                           max_iterations=10000000000)
 
-# Save in cgs
-dataset = {'HI'   :fc['HI']   *fc.chemistry_data.density_units,
-           'HII'  :fc['HII']  *fc.chemistry_data.density_units,
-           'HeI'  :fc['HeI']  *fc.chemistry_data.density_units,
-           'HeII' :fc['HeII'] *fc.chemistry_data.density_units,
-           'HeIII':fc['HeIII']*fc.chemistry_data.density_units,
-           'HM'   :fc['HM']   *fc.chemistry_data.density_units,
-           'H2I'  :fc['H2I']  *fc.chemistry_data.density_units,
-           'H2II' :fc['H2II'] *fc.chemistry_data.density_units,
-           'de'   :fc['de']   *fc.chemistry_data.density_units,
-           'metal':fc['metal']*fc.chemistry_data.density_units,
+# Save as fraction
+dataset = {'HI'   :fc['HI']   /fc['density'],
+           'HII'  :fc['HII']  /fc['density'],
+           'HeI'  :fc['HeI']  /fc['density'],
+           'HeII' :fc['HeII'] /fc['density'],
+           'HeIII':fc['HeIII']/fc['density'],
+           'HM'   :fc['HM']   /fc['density'],
+           'H2I'  :fc['H2I']  /fc['density'],
+           'H2II' :fc['H2II'] /fc['density'],
+           'de'   :fc['de']   /fc['density'],
+           'metal':fc['metal']/fc['density'],
            'density': dens,
            'temperature': temp}
 
@@ -92,5 +97,5 @@ field_types = {'HI'   :'table',
                'density': 'indexer',
                'temperature': 'indexer'}
 
-yt.save_as_dataset(None, f'equilibrium_table_{size_1d}_0{z*100:.0f}-Zsun.h5', dataset,
+yt.save_as_dataset(None, f'equilibrium_table_{size_1d}_0{Z*100:.0f}-Zsun.h5', dataset,
                    field_types = field_types)

--- a/src/enzo/EvolveLevel.C
+++ b/src/enzo/EvolveLevel.C
@@ -409,7 +409,7 @@ int EvolveLevel(TopGridData *MetaData, LevelHierarchyEntry *LevelArray[],
     /* Currently (September 2023) this is only implemented for H2REG_STAR
     and NORMAL_STAR. MakeStars is completely ignored in all other star makers. */
 
-    if ( (STARMAKE_METHOD(H2REG_STAR)) && 
+    if ( (STARMAKE_METHOD(H2REG_STAR) || STARMAKE_METHOD(NORMAL_STAR)) && 
 	 (level==0) && 
 	 (StarFormationOncePerRootGridTimeStep) ) {
       /* At top level, set Grid::MakeStars to 1 for all highest

--- a/src/enzo/EvolveLevel.C
+++ b/src/enzo/EvolveLevel.C
@@ -406,21 +406,21 @@ int EvolveLevel(TopGridData *MetaData, LevelHierarchyEntry *LevelArray[],
     prevent further star formation until the next root grid time
     step. */
 
-    /* Currently (April 2012) this is only implemented for H2REG_STAR,
-    and MakeStars is completely ignored in all other star makers. */
+    /* Currently (September 2023) this is only implemented for H2REG_STAR
+    and NORMAL_STAR. MakeStars is completely ignored in all other star makers. */
 
     if ( (STARMAKE_METHOD(H2REG_STAR)) && 
 	 (level==0) && 
 	 (StarFormationOncePerRootGridTimeStep) ) {
       /* At top level, set Grid::MakeStars to 1 for all highest
-	 refinement level grids. */
+        refinement level grids. */
       LevelHierarchyEntry *Temp;
       Temp = LevelArray[MaximumRefinementLevel];
       int count=0;
       while (Temp != NULL) {
-	Temp->GridData->SetMakeStars();
-	Temp = Temp->NextGridThisLevel;
-	count++;
+        Temp->GridData->SetMakeStars();
+        Temp = Temp->NextGridThisLevel;
+        count++;
       }
       // if(MyProcessorNumber == ROOT_PROCESSOR) 
       // 	fprintf(stderr,"Set MakeStars=1 for %d MaximumRefinementLevel grids.\n",count);

--- a/src/enzo/EvolveLevel.C
+++ b/src/enzo/EvolveLevel.C
@@ -412,18 +412,17 @@ int EvolveLevel(TopGridData *MetaData, LevelHierarchyEntry *LevelArray[],
     if ( (STARMAKE_METHOD(H2REG_STAR) || STARMAKE_METHOD(NORMAL_STAR)) && 
 	 (level==0) && 
 	 (StarFormationOncePerRootGridTimeStep) ) {
-      /* At top level, set Grid::MakeStars to 1 for all highest
-        refinement level grids. */
+      /* At top level, set Grid::MakeStars to 1 for all grids.
+         Individual star maker routines will need to check
+         whether or not each cell is the highest refined. */
       LevelHierarchyEntry *Temp;
-      Temp = LevelArray[MaximumRefinementLevel];
-      int count=0;
-      while (Temp != NULL) {
-        Temp->GridData->SetMakeStars();
-        Temp = Temp->NextGridThisLevel;
-        count++;
+      for (int i = level; i < MAX_DEPTH_OF_HIERARCHY; i++){
+        Temp = LevelArray[i];
+        while (Temp != NULL) {
+          Temp->GridData->SetMakeStars();
+          Temp = Temp->NextGridThisLevel;
+        }
       }
-      // if(MyProcessorNumber == ROOT_PROCESSOR) 
-      // 	fprintf(stderr,"Set MakeStars=1 for %d MaximumRefinementLevel grids.\n",count);
 
       TopGridTimeStep = LevelArray[0]->GridData->ReturnTimeStep();
 

--- a/src/enzo/GalaxySimulationInitialize.C
+++ b/src/enzo/GalaxySimulationInitialize.C
@@ -494,6 +494,7 @@ int GalaxySimulationInitialize(FILE *fptr, FILE *Outfptr,
     if (MetaData.TopGridRank > 2)
       Exterior.InitializeExternalBoundaryFace(2, inflow, outflow,
 					      InflowValue, Dummy);
+    Exterior.InitializeExternalBoundaryParticles(MetaData.ParticleBoundaryType);
 	
     /* Set Global Variables for RPS Wind (see ExternalBoundary_SetGalaxySimulationBoundary.C)*/
 

--- a/src/enzo/Grid.h
+++ b/src/enzo/Grid.h
@@ -148,8 +148,8 @@ class grid
 
 // For once-per-rootgrid-timestep star formation, the following flag
 // determines whether SF is about to occur or not. It's currently
-//(April 2012) only implemented for H2REG_STAR and completely
-// ignored for all other star makers.
+// (September 2023) only implemented for H2REG_STAR and NORMAL_STAR
+// but completely ignored for all other star makers.
   int MakeStars;
 
 //

--- a/src/enzo/Grid_NestedCosmologySimulationInitializeGrid.C
+++ b/src/enzo/Grid_NestedCosmologySimulationInitializeGrid.C
@@ -1474,19 +1474,6 @@ int grid::NestedCosmologySimulationInitializeGrid(
 
 	if (CosmologySimulationManuallySetParticleMassRatio == FALSE) {
 
-	  // If there are exactly 1/8 as many particles as cells,
-	  // then set the particle mass to 8 times the usual
-    
-	  int NumberOfActiveCells = (GridEndIndex[0]-GridStartIndex[0]+1)*
-	    (GridEndIndex[1]-GridStartIndex[1]+1)*
-	    (GridEndIndex[2]-GridStartIndex[2]+1);
-	  if (NumberOfParticles*8 == NumberOfActiveCells)
-	    UniformParticleMass *= 8;
-	  if (NumberOfParticles == NumberOfActiveCells*8)
-	    UniformParticleMass /= 8;
- 
-	  //      UniformParticleMass *= float(POW(TotalRefinement, GridRank));
- 
 	  // Issue a warning if PPIO or PRGIO are on (possibility of errors
 	  // being caused)
 	  if( ((ParallelParticleIO == TRUE) || (ParallelRootGridIO == TRUE)) &&

--- a/src/enzo/Grid_StarParticleHandler.C
+++ b/src/enzo/Grid_StarParticleHandler.C
@@ -806,39 +806,55 @@ int grid::StarParticleHandler(HierarchyEntry* SubgridPointer, int level,
     }
 #endif /* STAR1 */
  
-    if (STARMAKE_METHOD(NORMAL_STAR)) {
+    if (STARMAKE_METHOD(NORMAL_STAR) &&
+       ( this->MakeStars || !StarFormationOncePerRootGridTimeStep )){
 
       //---- MODIFIED CEN OSTRIKER FOLLOWING HOPKINS ET AL 2013 ("STANDARD VERSION")
 
       NumberOfNewParticlesSoFar = NumberOfNewParticles;
+      
+      /* If StarFormationOncePerRootGridTimeStep, use the root grid
+         timestep for the star particle creation. Stars are only
+         created once per root level time step. */
+      float TimeStep;
+      if(StarFormationOncePerRootGridTimeStep)
+         TimeStep = TopGridTimeStep;
+      else
+         TimeStep = dtFixed;
 
       FORTRAN_NAME(star_maker2)(
-       GridDimension, GridDimension+1, GridDimension+2,
-       BaryonField[DensNum], dmfield, temperature, BaryonField[Vel1Num],
-       BaryonField[Vel2Num], BaryonField[Vel3Num], BaryonField[H2INum],
-       cooling_time,
-       &dtFixed, BaryonField[NumberOfBaryonFields], MetalPointer,
-       &CellWidthTemp, &Time, &zred, &MyProcessorNumber,
-       &DensityUnits, &LengthUnits, &VelocityUnits, &TimeUnits,
-       &MaximumNumberOfNewParticles, CellLeftEdge[0], CellLeftEdge[1],
-       CellLeftEdge[2], &GhostZones,
-       &MetallicityField, &HydroMethod, &StarMakerTimeIndependentFormation,
-       &StarMakerMinimumDynamicalTime,
-       &StarMakerVelDivCrit, &StarMakerSelfBoundCrit, 
-       &StarMakerThermalCrit, &StarMakerUseJeansMass, &StarMakerH2Crit, 
-       &StarMakerOverDensityThreshold, &StarMakerMassEfficiency,
-       &StarMakerMinimumMass, &StarMakerTemperatureThreshold,
-       &level, &NumberOfNewParticles, 
-       tg->ParticlePosition[0], tg->ParticlePosition[1],
-          tg->ParticlePosition[2],
-       tg->ParticleVelocity[0], tg->ParticleVelocity[1],
-          tg->ParticleVelocity[2],
-       tg->ParticleMass, tg->ParticleAttribute[1], tg->ParticleAttribute[0],
-       tg->ParticleAttribute[2],
-       &StarMakerTypeIaSNe, BaryonField[MetalIaNum], tg->ParticleAttribute[3]);
+      GridDimension, GridDimension+1, GridDimension+2,
+      BaryonField[DensNum], dmfield, temperature, BaryonField[Vel1Num],
+      BaryonField[Vel2Num], BaryonField[Vel3Num], BaryonField[H2INum],
+      cooling_time,
+      &TimeStep, BaryonField[NumberOfBaryonFields], MetalPointer,
+      &CellWidthTemp, &Time, &zred, &MyProcessorNumber,
+      &DensityUnits, &LengthUnits, &VelocityUnits, &TimeUnits,
+      &MaximumNumberOfNewParticles, CellLeftEdge[0], CellLeftEdge[1],
+      CellLeftEdge[2], &GhostZones,
+      &MetallicityField, &HydroMethod, &StarMakerTimeIndependentFormation,
+      &StarMakerMinimumDynamicalTime,
+      &StarMakerVelDivCrit, &StarMakerSelfBoundCrit, 
+      &StarMakerThermalCrit, &StarMakerUseJeansMass, &StarMakerH2Crit, 
+      &StarMakerOverDensityThreshold, &StarMakerMassEfficiency,
+      &StarMakerMinimumMass, &StarMakerTemperatureThreshold,
+      &level, &NumberOfNewParticles, 
+      tg->ParticlePosition[0], tg->ParticlePosition[1],
+         tg->ParticlePosition[2],
+      tg->ParticleVelocity[0], tg->ParticleVelocity[1],
+         tg->ParticleVelocity[2],
+      tg->ParticleMass, tg->ParticleAttribute[1], tg->ParticleAttribute[0],
+      tg->ParticleAttribute[2],
+      &StarMakerTypeIaSNe, BaryonField[MetalIaNum], tg->ParticleAttribute[3]);
 
       for (i = NumberOfNewParticlesSoFar; i < NumberOfNewParticles; i++)
-          tg->ParticleType[i] = NormalStarType;
+         tg->ParticleType[i] = NormalStarType;
+
+         /* If StarFormationOncePerRootGridTimeStep, reset
+	      this::MakeStars to 0, to prevent further star formation until
+	      next top level time step has been taken. */
+      if(StarFormationOncePerRootGridTimeStep)
+         this->MakeStars = 0;
     }
 
     if (STARMAKE_METHOD(MOM_STAR)) {

--- a/src/enzo/Make.mach.ubuntu
+++ b/src/enzo/Make.mach.ubuntu
@@ -60,8 +60,8 @@ MACH_DEFINES   = -DLINUX -DH5_USE_16_API
 MACH_CPPFLAGS = -P -traditional 
 MACH_CFLAGS   = 
 MACH_CXXFLAGS =
-MACH_FFLAGS   = -finteger-4-integer-8 -fno-second-underscore -ffixed-line-length-132
-MACH_F90FLAGS = -finteger-4-integer-8 -fno-second-underscore
+MACH_FFLAGS   = -fallow-argument-mismatch -finteger-4-integer-8 -fno-second-underscore -ffixed-line-length-132
+MACH_F90FLAGS = -fallow-argument-mismatch -finteger-4-integer-8 -fno-second-underscore
 MACH_LDFLAGS  = 
 
 #-----------------------------------------------------------------------

--- a/src/enzo/Make.mach.ubuntu
+++ b/src/enzo/Make.mach.ubuntu
@@ -60,8 +60,8 @@ MACH_DEFINES   = -DLINUX -DH5_USE_16_API
 MACH_CPPFLAGS = -P -traditional 
 MACH_CFLAGS   = 
 MACH_CXXFLAGS =
-MACH_FFLAGS   = -fno-second-underscore -ffixed-line-length-132
-MACH_F90FLAGS = -fno-second-underscore
+MACH_FFLAGS   = -finteger-4-integer-8 -fno-second-underscore -ffixed-line-length-132
+MACH_F90FLAGS = -finteger-4-integer-8 -fno-second-underscore
 MACH_LDFLAGS  = 
 
 #-----------------------------------------------------------------------

--- a/src/enzo/Make.mach.ubuntu
+++ b/src/enzo/Make.mach.ubuntu
@@ -60,8 +60,8 @@ MACH_DEFINES   = -DLINUX -DH5_USE_16_API
 MACH_CPPFLAGS = -P -traditional 
 MACH_CFLAGS   = 
 MACH_CXXFLAGS =
-MACH_FFLAGS   = -fallow-argument-mismatch -finteger-4-integer-8 -fno-second-underscore -ffixed-line-length-132
-MACH_F90FLAGS = -fallow-argument-mismatch -finteger-4-integer-8 -fno-second-underscore
+MACH_FFLAGS   = -std=legacy -fno-second-underscore -ffixed-line-length-132
+MACH_F90FLAGS = -std=legacy -fno-second-underscore
 MACH_LDFLAGS  = 
 
 #-----------------------------------------------------------------------

--- a/src/enzo/ReadEquilibriumTable.C
+++ b/src/enzo/ReadEquilibriumTable.C
@@ -422,26 +422,7 @@ int ReadEquilibriumTable(char* name, FLOAT Time)
     EquilibriumTable.density[i] /= DensityUnits;
     //EquilibriumTable.temperature[i] /= TemperatureUnits; // keep in K
   }
-  // for (int i=0; i<EquilibriumTable.dim_size*EquilibriumTable.dim_size; ++i){
-  //   if (MultiSpecies) {
-  //     EquilibriumTable.HI[i] /= DensityUnits;
-  //     EquilibriumTable.HII[i] /= DensityUnits;
-  //     EquilibriumTable.HeI[i] /= DensityUnits;
-  //     EquilibriumTable.HeII[i] /= DensityUnits;
-  //     EquilibriumTable.HeIII[i] /= DensityUnits;
-  //     EquilibriumTable.de[i] /= DensityUnits;
-  //     if (MultiSpecies > 1) {
-  //       EquilibriumTable.HM[i] /= DensityUnits;
-  //       EquilibriumTable.H2I[i] /= DensityUnits;
-  //       EquilibriumTable.H2II[i] /= DensityUnits;
-  //     }
-  //     if (MultiSpecies > 2) {
-  //       EquilibriumTable.DI[i] /= DensityUnits;
-  //       EquilibriumTable.DII[i] /= DensityUnits;
-  //       EquilibriumTable.HDI[i] /= DensityUnits;
-  //     }
-  //   }
-  // }
+
 
   return SUCCESS;
 }


### PR DESCRIPTION
## Merge Enzo Main

This PR had latest Enzo main merged.

### Notes
I don't know why using `precision-32` cannot compile Enzo itself (without `libyt`). There is error in `GridComputeCoolingTime`. This problem isn't in libyt, so I'll just ignore it.

### Testing
Test libyt:
- [x] Compare in situ and post-processing
  - [x] Use `CosmologySimulation/amr_cosmology` to test loading particle and field data
  - [x] Compare in situ analysis results to `CollapseTestNonCosmological` (Quick Start) results
- [x] Make sure interactive mode work
- [x] Make sure reloading script work
- [x] Make sure jupyter notebook work