### PR TITLE
Make Python Script Name a Global Variable

### DIFF
--- a/doc/manual/source/user_guide/InSituPythonAnalysis.rst
+++ b/doc/manual/source/user_guide/InSituPythonAnalysis.rst
@@ -80,14 +80,14 @@ General
 * **How to change import Python file name?**
 
   The default Python script will be imported is ``inline.py``.
-  If we really want to change the name, we can go to
-  ``src/enzo/InitializeLibytInterface.C`` in function ``InitializeLibytByItself``, and change ``params->script`` to our Python file name without ``.py``. For example, I want to make it to ``test.py``:
+
+  If we want to change the script name, set the file name without its extension to ``libyt_script_name`` in Enzo parameter file.
+  For example, we want to make the Python script to be ``test.py``:
 
   ::
 
-      params->script = "test";
+      libyt_script_name = test
 
-  Please use ``const char*``, or else, we have to make sure the lifetime of this variable covers the whole in situ process.
 
 * **How to activate in situ Python analysis process?**
 

--- a/src/enzo/InitializeLibytInterface.C
+++ b/src/enzo/InitializeLibytInterface.C
@@ -33,6 +33,7 @@
 #endif
 
 
+extern char libyt_script_name[512];
 extern void* param_yt;
 extern void* param_libyt;
 

--- a/src/enzo/InitializeLibytInterface.C
+++ b/src/enzo/InitializeLibytInterface.C
@@ -43,9 +43,9 @@ int InitializeLibytByItself(long long argc, char *argv[])
     param_yt = (void*) malloc(sizeof(yt_param_yt));
     yt_param_libyt *params = (yt_param_libyt*) param_libyt;
     params->verbose = YT_VERBOSE_INFO;
-    params->script = "inline";     // inline.py will be loaded
-    params->counter = 0;           // Fig basename will start from count 0
-    params->check_data = false;    // do not check hierarchy
+    params->script = libyt_script_name;  // inline.py will be loaded
+    params->counter = 0;                 // Fig basename will start from count 0
+    params->check_data = false;          // do not check hierarchy
     yt_initialize(argc, argv, params);
     fprintf(stderr, "Finished calling initialize!\n");
     return 0;

--- a/src/enzo/ReadParameterFile.C
+++ b/src/enzo/ReadParameterFile.C
@@ -1191,6 +1191,7 @@ int ReadParameterFile(FILE *fptr, TopGridData &MetaData, float *Initialdt)
     ret += sscanf(line, "NumberOfLibytCalls = %"ISYM, &NumberOfLibytCalls);
     ret += sscanf(line, "NumberOfLibytTopGridCalls = %"ISYM, &NumberOfLibytTopGridCalls);
     ret += sscanf(line, "NumberOfLibytSubcycleCalls = %"ISYM, &NumberOfLibytSubcycleCalls);
+    ret += sscanf(line, "libyt_script_name = %s", libyt_script_name);
 #endif
 
     /* EnzoTiming Parameters */

--- a/src/enzo/SetDefaultGlobalValues.C
+++ b/src/enzo/SetDefaultGlobalValues.C
@@ -968,6 +968,10 @@ int SetDefaultGlobalValues(TopGridData &MetaData)
   my_processor = PyLong_FromLong((Eint) MyProcessorNumber);
 #endif
 
+#ifdef USE_LIBYT
+  strcpy(libyt_script_name, "inline");
+#endif
+
   /* Some stateful variables for EvolveLevel */
   for(i = 0; i < MAX_DEPTH_OF_HIERARCHY; i++) {
     LevelCycleCount[i] = LevelSubCycleCount[i] = 0;

--- a/src/enzo/WriteParameterFile.C
+++ b/src/enzo/WriteParameterFile.C
@@ -181,6 +181,7 @@ int WriteParameterFile(FILE *fptr, TopGridData &MetaData, char *name = NULL)
   fprintf(fptr, "NumberOfLibytCalls         = %"ISYM"\n", NumberOfLibytCalls);
   fprintf(fptr, "NumberOfLibytTopGridCalls  = %"ISYM"\n", NumberOfLibytTopGridCalls);
   fprintf(fptr, "NumberOfLibytSubcycleCalls = %"ISYM"\n", NumberOfLibytSubcycleCalls);
+  fprintf(fptr, "libyt_script_name = %s\n", libyt_script_name);
 #endif
 
   fprintf(fptr, "TimingCycleSkip             = %"ISYM"\n", TimingCycleSkip);

--- a/src/enzo/global_data.h
+++ b/src/enzo/global_data.h
@@ -980,7 +980,7 @@ EXTERN PyObject *my_processor;
 #endif
 
 #ifdef USE_LIBYT
-EXTERN char libyt_script_name[MAX_LINE_LENGTH];
+EXTERN char libyt_script_name[512];
 EXTERN void *param_libyt;
 EXTERN void *param_yt;
 EXTERN int libyt_field_lookup[FieldUndefined];

--- a/src/enzo/global_data.h
+++ b/src/enzo/global_data.h
@@ -980,6 +980,7 @@ EXTERN PyObject *my_processor;
 #endif
 
 #ifdef USE_LIBYT
+EXTERN char libyt_script_name[MAX_LINE_LENGTH];
 EXTERN void *param_libyt;
 EXTERN void *param_yt;
 EXTERN int libyt_field_lookup[FieldUndefined];


### PR DESCRIPTION
Make Python script name a global variable, and can set it through `libyt_script_name` in Enzo parameter file.

The default value is `inline`, and it will import `inline.py`.
The following will import `test.py`:
```txt
libyt_script_name = test
```