### PR TITLE
Fix

### DIFF
--- a/doc/manual/source/user_guide/InSituPythonAnalysis.rst
+++ b/doc/manual/source/user_guide/InSituPythonAnalysis.rst
@@ -36,17 +36,17 @@ Please follow the instructions in ``libyt`` documents:
 
   * `yt`_: An open-source, permissively-licensed python package for analyzing and visualizing volumetric data.
 
-  * `yt_libyt`_: ``libyt``'s yt frontend.
+  * `yt_libyt`_ (>=0.0.9): ``libyt``'s yt frontend.
 
   * `jupyter_libyt`_: A Jupyter Client plugin for connecting to libyt Jupyter kernel. This is only required in **jupyter kernel mode**.
 
-.. _libyt: https://libyt.readthedocs.io/en/latest/how-to-install.html#c-library-libyt
+.. _libyt: https://libyt.readthedocs.io/en/latest/
 
 .. _yt: https://yt-project.org
 
-.. _yt_libyt: https://libyt.readthedocs.io/en/latest/how-to-install.html#yt-libyt
+.. _yt_libyt: https://github.com/data-exp-lab/yt_libyt
 
-.. _jupyter_libyt: https://libyt.readthedocs.io/en/latest/how-to-install.html#jupyter-libyt
+.. _jupyter_libyt: https://github.com/yt-project/jupyter_libyt
 
 .. _mpi4py: https://mpi4py.readthedocs.io/en/stable/install.html#installation
 

--- a/doc/manual/source/user_guide/InSituPythonAnalysis.rst
+++ b/doc/manual/source/user_guide/InSituPythonAnalysis.rst
@@ -18,7 +18,7 @@ We can compile ``libyt`` using different options based on our used cases, so tha
 A brief description of each mode (option) is shown here. The options are for compiling ``libyt`` only, and they are mutually independent.
 Please follow the instructions in ``libyt`` documents:
 
-* `libyt`_: a C shared library for in situ analysis.
+* `libyt`_ (>=0.1.0, <1.0): a C shared library for in situ analysis.
 
   * **Serial Mode** (``-DSERIAL_MODE=ON``): Compile ``libyt`` using GCC compiler.
 
@@ -36,9 +36,9 @@ Please follow the instructions in ``libyt`` documents:
 
   * `yt`_: An open-source, permissively-licensed python package for analyzing and visualizing volumetric data.
 
-  * `yt_libyt`_ (>=0.0.9): ``libyt``'s yt frontend.
+  * `yt_libyt`_ (>=0.1.0, <1.0): ``libyt``'s yt frontend.
 
-  * `jupyter_libyt`_: A Jupyter Client plugin for connecting to libyt Jupyter kernel. This is only required in **jupyter kernel mode**.
+  * `jupyter_libyt`_ (>=0.1.0, <1.0): A Jupyter Client plugin for connecting to libyt Jupyter kernel. This is only required in **jupyter kernel mode**.
 
 .. _libyt: https://libyt.readthedocs.io/en/latest/
 

--- a/doc/manual/source/user_guide/InSituPythonAnalysis.rst
+++ b/doc/manual/source/user_guide/InSituPythonAnalysis.rst
@@ -295,7 +295,7 @@ Please add ``OMPI_MCA_osc=sm,pt2pt`` before ``mpirun``, for example:
 
     OMPI_MCA_osc=sm,pt2pt mpirun -np 4 ./enzo.exe -d CollapseTestNonCosmological.enzo
 
-This is something ``libyt`` will update and improve in the future.
+It is for one-sided MPI communication settings.
 
 .. _Doing In Situ Analysis:
 

--- a/doc/manual/source/user_guide/InSituPythonAnalysis.rst
+++ b/doc/manual/source/user_guide/InSituPythonAnalysis.rst
@@ -18,7 +18,7 @@ We can compile ``libyt`` using different options based on our used cases, so tha
 A brief description of each mode (option) is shown here. The options are for compiling ``libyt`` only, and they are mutually independent.
 Please follow the instructions in ``libyt`` documents:
 
-* `libyt`_ (>=0.1.0, <1.0): a C shared library for in situ analysis.
+* `libyt`_ (>=0.2.0, <1.0): a C shared library for in situ analysis.
 
   * **Serial Mode** (``-DSERIAL_MODE=ON``): Compile ``libyt`` using GCC compiler.
 
@@ -36,9 +36,9 @@ Please follow the instructions in ``libyt`` documents:
 
   * `yt`_: An open-source, permissively-licensed python package for analyzing and visualizing volumetric data.
 
-  * `yt_libyt`_ (>=0.1.0, <1.0): ``libyt``'s yt frontend.
+  * `yt_libyt`_ (>=0.2.0, <1.0): ``libyt``'s yt frontend.
 
-  * `jupyter_libyt`_ (>=0.1.0, <1.0): A Jupyter Client plugin for connecting to libyt Jupyter kernel. This is only required in **jupyter kernel mode**.
+  * `jupyter_libyt`_ (>=0.2.0, <1.0): A Jupyter Client plugin for connecting to libyt Jupyter kernel. This is only required in **jupyter kernel mode**.
 
 .. _libyt: https://libyt.readthedocs.io/en/latest/
 

--- a/src/enzo/ActiveParticle.h
+++ b/src/enzo/ActiveParticle.h
@@ -473,7 +473,7 @@ namespace ActiveParticleHelpers {
       return attribute_datatype;
   }
 
-  template <class APClass> std::vector<std::string> GetParticleAttributes() {
+  template <class APClass> std::vector<std::string> GetParticleAttributeNames() {
 
       std::vector<std::string> attributes;
 
@@ -711,7 +711,7 @@ public:
                        int OutCount),
    int (*element_size)(void),
    std::vector<hid_t> (*get_particle_attributes_hdf5_datatype)(void),
-   std::vector<std::string> (*get_particle_attributes)(void),
+   std::vector<std::string> (*get_particle_attribute_names)(void),
    void (*write_particles)(ActiveParticleList<ActiveParticleType> &particles,
                          int type_id, int total_particles,
                          const std::string name, hid_t node),
@@ -735,7 +735,7 @@ public:
     this->UnpackBuffer = unpack_buffer;
     this->ReturnElementSize = element_size;
     this->GetParticleAttributesHDF5DataType = get_particle_attributes_hdf5_datatype;
-    this->GetParticleAttributes = get_particle_attributes;
+    this->GetParticleAttributeNames = get_particle_attribute_names;
     this->WriteParticles = write_particles;
     this->ReadParticles = read_particles;
     this->ResetAcceleration = reset_acceleration;
@@ -782,7 +782,7 @@ public:
   int (*FillBuffer)(ActiveParticleList<ActiveParticleType> &InList, int InCount, char *buffer);
   int (*ReturnElementSize)(void);
   std::vector<hid_t> (*GetParticleAttributesHDF5DataType)(void);
-  std::vector<std::string> (*GetParticleAttributes)(void);
+  std::vector<std::string> (*GetParticleAttributeNames)(void);
   void (*WriteParticles)(ActiveParticleList<ActiveParticleType> &InList,
                        int ParticleTypeID, int TotalParticles,
                        const std::string name, hid_t node);
@@ -823,7 +823,7 @@ ActiveParticleType_info *register_ptype(std::string name)
      (&ActiveParticleHelpers::Unpack<APClass>),
      (&ActiveParticleHelpers::CalculateElementSize<APClass>),
      (&ActiveParticleHelpers::GetParticleAttributesHDF5DataType<APClass>),
-     (&ActiveParticleHelpers::GetParticleAttributes<APClass>),
+     (&ActiveParticleHelpers::GetParticleAttributeNames<APClass>),
      (&ActiveParticleHelpers::WriteParticles<APClass>),
      (&ActiveParticleHelpers::ReadParticles<APClass>),
      (&APClass::ResetAcceleration),

--- a/src/enzo/ActiveParticle.h
+++ b/src/enzo/ActiveParticle.h
@@ -496,6 +496,7 @@ namespace ActiveParticleHelpers {
           else {
               int size = Count * (*it)->element_size;
               char *buffer = new char [size];
+              char *_buffer = buffer; // This is because GetAttribute _shifts_ the pointer after returning
 
               for (int i = 0; i < TotalParticles; i++) {
                   if (InList[i]->GetEnabledParticleID() != ParticleTypeID) {
@@ -504,7 +505,7 @@ namespace ActiveParticleHelpers {
                   (*it)->GetAttribute(&buffer, InList[i]);
               }
 
-              attribute_values.push_back((void*) buffer);
+              attribute_values.push_back((void*) _buffer);
           }
       }
 

--- a/src/enzo/ActiveParticle.h
+++ b/src/enzo/ActiveParticle.h
@@ -462,6 +462,18 @@ namespace ActiveParticleHelpers {
 
   }
 
+  template <class APClass> std::vector<std::string> GetParticleAttributes() {
+
+      std::vector<std::string> attributes;
+
+      AttributeVector &handlers = APClass::AttributeHandlers;
+      for (AttributeVector::iterator it = handlers.begin(); it != handlers.end(); ++it) {
+          attributes.push_back((*it)->name);
+      }
+
+      return attributes;
+  }
+
   template <class APClass> void WriteParticles(
           ActiveParticleList<ActiveParticleType>& InList, int ParticleTypeID,
           int TotalParticles,
@@ -687,6 +699,7 @@ public:
    void (*unpack_buffer)(char *buffer, int offset, ActiveParticleList<ActiveParticleType> &Outlist,
                        int OutCount),
    int (*element_size)(void),
+   std::vector<std::string> (*get_particle_attributes)(void),
    void (*write_particles)(ActiveParticleList<ActiveParticleType> &particles,
                          int type_id, int total_particles,
                          const std::string name, hid_t node),
@@ -709,6 +722,7 @@ public:
     this->AllocateBuffer = allocate_buffer;
     this->UnpackBuffer = unpack_buffer;
     this->ReturnElementSize = element_size;
+    this->GetParticleAttributes = get_particle_attributes;
     this->WriteParticles = write_particles;
     this->ReadParticles = read_particles;
     this->ResetAcceleration = reset_acceleration;
@@ -754,6 +768,7 @@ public:
                        int OutCount);
   int (*FillBuffer)(ActiveParticleList<ActiveParticleType> &InList, int InCount, char *buffer);
   int (*ReturnElementSize)(void);
+  std::vector<std::string> (*GetParticleAttributes)(void);
   void (*WriteParticles)(ActiveParticleList<ActiveParticleType> &InList,
                        int ParticleTypeID, int TotalParticles,
                        const std::string name, hid_t node);
@@ -793,6 +808,7 @@ ActiveParticleType_info *register_ptype(std::string name)
      (&ActiveParticleHelpers::FillBuffer<APClass>),
      (&ActiveParticleHelpers::Unpack<APClass>),
      (&ActiveParticleHelpers::CalculateElementSize<APClass>),
+     (&ActiveParticleHelpers::GetParticleAttributes<APClass>),
      (&ActiveParticleHelpers::WriteParticles<APClass>),
      (&ActiveParticleHelpers::ReadParticles<APClass>),
      (&APClass::ResetAcceleration),

--- a/src/enzo/ActiveParticle.h
+++ b/src/enzo/ActiveParticle.h
@@ -508,7 +508,7 @@ namespace ActiveParticleHelpers {
           }
       }
 
-      return attribute_values
+      return attribute_values;
   }
 
   template <class APClass> std::vector<std::string> GetParticleAttributeNames() {
@@ -750,7 +750,7 @@ public:
    int (*element_size)(void),
    std::vector<hid_t> (*get_particle_attributes_hdf5_datatype)(void),
    std::vector<void*> (*get_particle_attributes)(ActiveParticleList<ActiveParticleType> &particles,
-                                                 int type_id, int total_particles, int count, const std::string& particle_name);
+                                                 int type_id, int total_particles, int count, const std::string& particle_name),
    std::vector<std::string> (*get_particle_attribute_names)(void),
    void (*write_particles)(ActiveParticleList<ActiveParticleType> &particles,
                          int type_id, int total_particles,

--- a/src/enzo/ActiveParticle.h
+++ b/src/enzo/ActiveParticle.h
@@ -487,9 +487,11 @@ namespace ActiveParticleHelpers {
       for (AttributeVector::iterator it = handlers.begin(); it != handlers.end(); ++it) {
           const char *attr_name = (*it)->name.c_str();
 
-          // ignores multi-dimensional arrays
-          if ((strcmp(attr_name, "AccretionRate") == 0 || strcmp(attr_name, "AccretionRateTime") == 0 || strcmp(attr_name, "Accreted_angmom") == 0)
-              && strcmp(particle_name.c_str(), "SmartStar") == 0) {
+          // Ignore multi-dimensional array (attribute that contains multiple values) for now
+          // If it is ArrayHandler class and attribute name != "particle_*", then element_size = sizeof(Type) * N.
+          // This is when a particle attribute contains multiple values and is stored in an array.
+          // (See how element_size is set in ParticleAttributeHandler.h)
+          if ((*it)->element_size / H5Tget_size((*it)->hdf5type) > 1) {
               attribute_values.push_back(nullptr);
           }
           // allocates memory and get a copy of the attribute's value

--- a/src/enzo/ActiveParticle.h
+++ b/src/enzo/ActiveParticle.h
@@ -462,6 +462,17 @@ namespace ActiveParticleHelpers {
 
   }
 
+  template <class APClass> std::vector<hid_t> GetParticleAttributesHDF5DataType() {
+      std::vector<hid_t> attribute_datatype;
+
+      AttributeVector &handlers = APClass::AttributeHandlers;
+      for (AttributeVector::iterator it = handlers.begin(); it != handlers.end(); ++it) {
+          attribute_datatype.push_back((*it)->hdf5type);
+      }
+
+      return attribute_datatype;
+  }
+
   template <class APClass> std::vector<std::string> GetParticleAttributes() {
 
       std::vector<std::string> attributes;
@@ -699,6 +710,7 @@ public:
    void (*unpack_buffer)(char *buffer, int offset, ActiveParticleList<ActiveParticleType> &Outlist,
                        int OutCount),
    int (*element_size)(void),
+   std::vector<hid_t> (*get_particle_attributes_hdf5_datatype)(void),
    std::vector<std::string> (*get_particle_attributes)(void),
    void (*write_particles)(ActiveParticleList<ActiveParticleType> &particles,
                          int type_id, int total_particles,
@@ -722,6 +734,7 @@ public:
     this->AllocateBuffer = allocate_buffer;
     this->UnpackBuffer = unpack_buffer;
     this->ReturnElementSize = element_size;
+    this->GetParticleAttributesHDF5DataType = get_particle_attributes_hdf5_datatype;
     this->GetParticleAttributes = get_particle_attributes;
     this->WriteParticles = write_particles;
     this->ReadParticles = read_particles;
@@ -768,6 +781,7 @@ public:
                        int OutCount);
   int (*FillBuffer)(ActiveParticleList<ActiveParticleType> &InList, int InCount, char *buffer);
   int (*ReturnElementSize)(void);
+  std::vector<hid_t> (*GetParticleAttributesHDF5DataType)(void);
   std::vector<std::string> (*GetParticleAttributes)(void);
   void (*WriteParticles)(ActiveParticleList<ActiveParticleType> &InList,
                        int ParticleTypeID, int TotalParticles,
@@ -808,6 +822,7 @@ ActiveParticleType_info *register_ptype(std::string name)
      (&ActiveParticleHelpers::FillBuffer<APClass>),
      (&ActiveParticleHelpers::Unpack<APClass>),
      (&ActiveParticleHelpers::CalculateElementSize<APClass>),
+     (&ActiveParticleHelpers::GetParticleAttributesHDF5DataType<APClass>),
      (&ActiveParticleHelpers::GetParticleAttributes<APClass>),
      (&ActiveParticleHelpers::WriteParticles<APClass>),
      (&ActiveParticleHelpers::ReadParticles<APClass>),

--- a/src/enzo/ActiveParticle.h
+++ b/src/enzo/ActiveParticle.h
@@ -473,6 +473,44 @@ namespace ActiveParticleHelpers {
       return attribute_datatype;
   }
 
+  template <class APClass> std::vector<void*> GetParticleAttributes(ActiveParticleList<ActiveParticleType>& InList,
+          int ParticleTypeID, int TotalParticles, int Count, const std::string& particle_name) {
+
+      // This function allocates and returns the new buffer for particle attributes,
+      // and it is the caller's responsibility to free the buffer when it doesn't need it at all.
+      // It also ignores multi-dimensional arrays.
+      // Currently, this function is solely used in libyt.
+
+      std::vector<void*> attribute_values;
+
+      AttributeVector &handlers = APClass::AttributeHandlers;
+      for (AttributeVector::iterator it = handlers.begin(); it != handlers.end(); ++it) {
+          const char *attr_name = (*it)->name.c_str();
+
+          // ignores multi-dimensional arrays
+          if ((strcmp(attr_name, "AccretionRate") == 0 || strcmp(attr_name, "AccretionRateTime") == 0 || strcmp(attr_name, "Accreted_angmom") == 0)
+              && strcmp(particle_name.c_str(), "SmartStar") == 0) {
+              attribute_values.push_back(nullptr);
+          }
+          // allocates memory and get a copy of the attribute's value
+          else {
+              int size = Count * (*it)->element_size;
+              char *buffer = new char [size];
+
+              for (int i = 0; i < TotalParticles; i++) {
+                  if (InList[i]->GetEnabledParticleID() != ParticleTypeID) {
+                      continue;
+                  }
+                  (*it)->GetAttribute(&buffer, InList[i]);
+              }
+
+              attribute_values.push_back((void*) buffer);
+          }
+      }
+
+      return attribute_values
+  }
+
   template <class APClass> std::vector<std::string> GetParticleAttributeNames() {
 
       std::vector<std::string> attributes;
@@ -711,6 +749,8 @@ public:
                        int OutCount),
    int (*element_size)(void),
    std::vector<hid_t> (*get_particle_attributes_hdf5_datatype)(void),
+   std::vector<void*> (*get_particle_attributes)(ActiveParticleList<ActiveParticleType> &particles,
+                                                 int type_id, int total_particles, int count, const std::string& particle_name);
    std::vector<std::string> (*get_particle_attribute_names)(void),
    void (*write_particles)(ActiveParticleList<ActiveParticleType> &particles,
                          int type_id, int total_particles,
@@ -735,6 +775,7 @@ public:
     this->UnpackBuffer = unpack_buffer;
     this->ReturnElementSize = element_size;
     this->GetParticleAttributesHDF5DataType = get_particle_attributes_hdf5_datatype;
+    this->GetParticleAttributes = get_particle_attributes;
     this->GetParticleAttributeNames = get_particle_attribute_names;
     this->WriteParticles = write_particles;
     this->ReadParticles = read_particles;
@@ -782,6 +823,9 @@ public:
   int (*FillBuffer)(ActiveParticleList<ActiveParticleType> &InList, int InCount, char *buffer);
   int (*ReturnElementSize)(void);
   std::vector<hid_t> (*GetParticleAttributesHDF5DataType)(void);
+  std::vector<void*> (*GetParticleAttributes)(ActiveParticleList<ActiveParticleType> &InList,
+                                              int ParticleTypeID, int TotalParticles, int Count,
+                                              const std::string& particle_name);
   std::vector<std::string> (*GetParticleAttributeNames)(void);
   void (*WriteParticles)(ActiveParticleList<ActiveParticleType> &InList,
                        int ParticleTypeID, int TotalParticles,
@@ -823,6 +867,7 @@ ActiveParticleType_info *register_ptype(std::string name)
      (&ActiveParticleHelpers::Unpack<APClass>),
      (&ActiveParticleHelpers::CalculateElementSize<APClass>),
      (&ActiveParticleHelpers::GetParticleAttributesHDF5DataType<APClass>),
+     (&ActiveParticleHelpers::GetParticleAttributes<APClass>),
      (&ActiveParticleHelpers::GetParticleAttributeNames<APClass>),
      (&ActiveParticleHelpers::WriteParticles<APClass>),
      (&ActiveParticleHelpers::ReadParticles<APClass>),

--- a/src/enzo/CallInSitulibyt.C
+++ b/src/enzo/CallInSitulibyt.C
@@ -202,7 +202,7 @@ int CallInSitulibyt(LevelHierarchyEntry *LevelArray[], TopGridData *MetaData,
 
     for (int i = 0; i < EnabledActiveParticlesCount; i++) {
         ActiveParticleType_info *ActiveParticleTypeToEvaluate = EnabledActiveParticles[i];
-        active_particles_attributes.emplace_back(ActiveParticleTypeToEvaluate->GetParticleAttributes());
+        active_particles_attributes.emplace_back(ActiveParticleTypeToEvaluate->GetParticleAttributeNames());
         active_particles_attributes_hdf5type.emplace_back(ActiveParticleTypeToEvaluate->GetParticleAttributesHDF5DataType());
 
         par_type_list[1 + i].par_type = ActiveParticleTypeToEvaluate->particle_name.c_str();

--- a/src/enzo/CallInSitulibyt.C
+++ b/src/enzo/CallInSitulibyt.C
@@ -297,6 +297,7 @@ int CallInSitulibyt(LevelHierarchyEntry *LevelArray[], TopGridData *MetaData,
 
     field_list[libyt_field_i].field_name = "Cooling_Time";
     field_list[libyt_field_i].field_type = "cell-centered";
+    field_list[libyt_field_i].field_unit = "code_time";
     field_list[libyt_field_i].field_dtype = EYT_BFLOAT;
     for (j = 0; j < 6; j++) {
         field_list[libyt_field_i].field_ghost_cell[j] = NumberOfGhostZones;

--- a/src/enzo/CallInSitulibyt.C
+++ b/src/enzo/CallInSitulibyt.C
@@ -186,9 +186,10 @@ int CallInSitulibyt(LevelHierarchyEntry *LevelArray[], TopGridData *MetaData,
         }
     }
 
-    params->num_fields += 2; // TODO: BH: add fields for Temperature/Cooling_Time derived field from enzo
+    // Add fields for Temperature/Cooling_Time derived field from enzo
+    params->num_fields += 2;
 
-    // TODO: PARTICLE need to add other ptypes (Active Ptype)
+    // Add active particle ptypes
     params->num_par_types = 1 + EnabledActiveParticlesCount; // DarkMatter and Other ActiveParticle (ex: SmartStar)
     yt_par_type *par_type_list = new yt_par_type [params->num_par_types];
 
@@ -436,10 +437,10 @@ int CallInSitulibyt(LevelHierarchyEntry *LevelArray[], TopGridData *MetaData,
         return FAIL;
     }
 
-    for (std::size_t i = 0; i < libyt_generated_derived_field.size(); i++) {
-        delete [] libyt_generated_derived_field[i];
+    for (std::size_t i = 0; i < libyt_generated_data.size(); i++) {
+        delete [] libyt_generated_data[i];
     }
-    libyt_generated_derived_field.clear();
+    libyt_generated_data.clear();
 
     CommunicationBarrier();
     return SUCCESS;

--- a/src/enzo/CallInSitulibyt.C
+++ b/src/enzo/CallInSitulibyt.C
@@ -18,6 +18,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <math.h>
 #include "ErrorExceptions.h"
 #include "macros_and_parameters.h"
 #include "typedefs.h"

--- a/src/enzo/CallInSitulibyt.C
+++ b/src/enzo/CallInSitulibyt.C
@@ -166,9 +166,9 @@ int CallInSitulibyt(LevelHierarchyEntry *LevelArray[], TopGridData *MetaData,
     params->time_unit = TimeUnits;
     params->velocity_unit = VelocityUnits;
     params->magnetic_unit = sqrt(4.0 * 3.141592653589793238462643383279502884L * DensityUnits) * VelocityUnits;
-    params->periodicity[0] = MetaData->LeftFaceBoundaryCondition[0];
-    params->periodicity[1] = MetaData->LeftFaceBoundaryCondition[1];
-    params->periodicity[2] = MetaData->LeftFaceBoundaryCondition[2];
+    params->periodicity[0] = (MetaData->LeftFaceBoundaryCondition[0] == periodic);
+    params->periodicity[1] = (MetaData->LeftFaceBoundaryCondition[1] == periodic);
+    params->periodicity[2] = (MetaData->LeftFaceBoundaryCondition[2] == periodic);
     params->dimensionality = MetaData->TopGridRank;
     params->domain_dimensions[0] = MetaData->TopGridDims[0];
     params->domain_dimensions[1] = MetaData->TopGridDims[1];

--- a/src/enzo/CallInSitulibyt.C
+++ b/src/enzo/CallInSitulibyt.C
@@ -391,6 +391,7 @@ int CallInSitulibyt(LevelHierarchyEntry *LevelArray[], TopGridData *MetaData,
     for (std::size_t i = 0; i < libyt_generated_derived_field.size(); i++) {
         delete [] libyt_generated_derived_field[i];
     }
+    libyt_generated_derived_field.clear();
 
     CommunicationBarrier();
     return SUCCESS;

--- a/src/enzo/CallInSitulibyt.C
+++ b/src/enzo/CallInSitulibyt.C
@@ -149,7 +149,7 @@ int CallInSitulibyt(LevelHierarchyEntry *LevelArray[], TopGridData *MetaData,
     params->length_unit = LengthUnits;
     params->mass_unit = DensityUnits * LengthUnits * LengthUnits * LengthUnits; /* this right? */
     params->time_unit = TimeUnits;
-    params->magnetic_unit = 0.0; /* Not right */
+    params->velocity_unit = VelocityUnits;
     params->periodicity[0] = 1; /* also not right */
     params->periodicity[1] = 1;
     params->periodicity[2] = 1;

--- a/src/enzo/CallInSitulibyt.C
+++ b/src/enzo/CallInSitulibyt.C
@@ -181,11 +181,16 @@ int CallInSitulibyt(LevelHierarchyEntry *LevelArray[], TopGridData *MetaData,
     par_type_list[0].par_type = "DarkMatter";
     par_type_list[0].num_attr = 3 + 3 + 1 + 1 + 1 + NumberOfParticleAttributes;
 
+    // the attributes name should be alive within the entire libyt in situ analysis,
+    // because libyt does not make a copy of the names.
+    std::vector<std::vector<std::string>> active_particles_attributes;
+
     for (int i = 0; i < EnabledActiveParticlesCount; i++) {
         ActiveParticleType_info *ActiveParticleTypeToEvaluate = EnabledActiveParticles[i];
+        active_particles_attributes.emplace_back(ActiveParticleTypeToEvaluate->GetParticleAttributes());
 
         par_type_list[1 + i].par_type = ActiveParticleTypeToEvaluate->particle_name.c_str();
-        par_type_list[1 + i].num_attr = (ActiveParticleTypeToEvaluate->GetParticleAttributes()).size();
+        par_type_list[1 + i].num_attr = active_particles_attributes[i].size();
     }
 
     params->par_type_list = par_type_list;
@@ -242,11 +247,8 @@ int CallInSitulibyt(LevelHierarchyEntry *LevelArray[], TopGridData *MetaData,
     particle_list[0].coor_z = attr_name[2];
 
     for (int i = 0; i < EnabledActiveParticlesCount; i++) {
-        ActiveParticleType_info *ActiveParticleTypeToEvaluate = EnabledActiveParticles[i];
-
-        std::vector<std::string> attributes = ActiveParticleTypeToEvaluate->GetParticleAttributes();
-        for (int v = 0; v < attributes.size(); v++) {
-            particle_list[1 + i].attr_list[v].attr_name = attributes[v].c_str();
+        for (int v = 0; v < active_particles_attributes[i].size(); v++) {
+            particle_list[1 + i].attr_list[v].attr_name = active_particles_attributes[i][v].c_str();
             // TODO: list attributes data type
         }
 

--- a/src/enzo/CallInSitulibyt.C
+++ b/src/enzo/CallInSitulibyt.C
@@ -45,17 +45,16 @@ void ExportParameterFile(TopGridData *MetaData, FLOAT CurrentTime, FLOAT OldTime
 void CommunicationBarrier();
 
 static yt_dtype MapHDF5TypeToYTType(hid_t hdf5type) {
-    switch (hdf5type) {
-        case HDF5_INT:
-            return EYT_INT;
-        case HDF5_REAL:
-            return EYT_BFLOAT;
-        case HDF5_R8:
-            return YT_DOUBLE;
-        case HDF5_PREC:
-            return EYT_PFLOAT;
-        default:
-            return YT_DTYPE_UNKNOWN;
+    if (hdf5type == HDF5_INT) {
+        return EYT_INT;
+    } else if (hdf5type == HDF5_REAL) {
+        return EYT_BFLOAT;
+    } else if (hdf5type == HDF5_R8) {
+        return YT_DOUBLE;
+    } else if (hdf5type == HDF5_PREC) {
+        return EYT_PFLOAT;
+    } else {
+        return YT_DTYPE_UNKNOWN;
     }
 }
 

--- a/src/enzo/CallInSitulibyt.C
+++ b/src/enzo/CallInSitulibyt.C
@@ -150,6 +150,7 @@ int CallInSitulibyt(LevelHierarchyEntry *LevelArray[], TopGridData *MetaData,
     params->mass_unit = DensityUnits * LengthUnits * LengthUnits * LengthUnits; /* this right? */
     params->time_unit = TimeUnits;
     params->velocity_unit = VelocityUnits;
+    params->magnetic_unit = sqrt(4.0 * 3.141592653589793238462643383279502884L * DensityUnits) * VelocityUnits;
     params->periodicity[0] = 1; /* also not right */
     params->periodicity[1] = 1;
     params->periodicity[2] = 1;

--- a/src/enzo/CallInSitulibyt.C
+++ b/src/enzo/CallInSitulibyt.C
@@ -151,9 +151,9 @@ int CallInSitulibyt(LevelHierarchyEntry *LevelArray[], TopGridData *MetaData,
     params->time_unit = TimeUnits;
     params->velocity_unit = VelocityUnits;
     params->magnetic_unit = sqrt(4.0 * 3.141592653589793238462643383279502884L * DensityUnits) * VelocityUnits;
-    params->periodicity[0] = 1; /* also not right */
-    params->periodicity[1] = 1;
-    params->periodicity[2] = 1;
+    params->periodicity[0] = MetaData->LeftFaceBoundaryCondition[0];
+    params->periodicity[1] = MetaData->LeftFaceBoundaryCondition[1];
+    params->periodicity[2] = MetaData->LeftFaceBoundaryCondition[2];
     params->dimensionality = MetaData->TopGridRank;
     params->domain_dimensions[0] = MetaData->TopGridDims[0];
     params->domain_dimensions[1] = MetaData->TopGridDims[1];

--- a/src/enzo/Grid_ConvertToLibyt.C
+++ b/src/enzo/Grid_ConvertToLibyt.C
@@ -93,14 +93,14 @@ void grid::ConvertToLibyt(int LocalGridID, int GlobalGridID, int ParentID, int l
     GetUnits(&DensityUnits, &LengthUnits, &TemperatureUnits, &TimeUnits, &VelocityUnits, this->Time);
 
     if (this->ComputeTemperatureField(temp_field) == SUCCESS) {
-        libyt_generated_derived_field.push_back(temp_field);
+        libyt_generated_data.push_back(temp_field);
         int temp_field_i = ((yt_param_yt*)param_yt)->num_fields - 2;
         GridInfo.field_data[temp_field_i].data_ptr = temp_field;
     }
 
     if (this->ComputeCoolingTime(cooling_time_field) == SUCCESS) {
         for (long i = 0; i < grid_size; i++) { cooling_time_field[i] = fabs(cooling_time_field[i]) * TimeUnits; }
-        libyt_generated_derived_field.push_back(cooling_time_field);
+        libyt_generated_data.push_back(cooling_time_field);
         int cooling_time_field_i = ((yt_param_yt*)param_yt)->num_fields - 1;
         GridInfo.field_data[cooling_time_field_i].data_ptr = cooling_time_field;
     }
@@ -130,7 +130,7 @@ void grid::ConvertToLibyt(int LocalGridID, int GlobalGridID, int ParentID, int l
         active_particle_count[(this->ActiveParticles)[i]->GetEnabledParticleID()]++;
     }
     for (int i = 0; i < EnabledActiveParticlesCount; i++) {
-        GridInfo.par_count_list[1 + i] = active_particle_count[i]; // TODO: check why 1483, 1484 both have count 1
+        GridInfo.par_count_list[1 + i] = active_particle_count[i];
     }
 
     /* fill in buffer only if there is active particle, which is sum of active particle count > 0
@@ -149,9 +149,8 @@ void grid::ConvertToLibyt(int LocalGridID, int GlobalGridID, int ParentID, int l
                 GridInfo.particle_data[1 + i][a].data_ptr = par_attr_buffer[a];
             }
 
-            // TODO: rename libyt_generated_derived_field
             // free these pre-allocated buffer after libyt in situ analysis is done.
-            libyt_generated_derived_field.insert(libyt_generated_derived_field.end(), par_attr_buffer.begin(), par_attr_buffer.end());
+            libyt_generated_data.insert(libyt_generated_data.end(), par_attr_buffer.begin(), par_attr_buffer.end());
         }
     }
 }

--- a/src/enzo/Grid_ConvertToLibyt.C
+++ b/src/enzo/Grid_ConvertToLibyt.C
@@ -87,7 +87,7 @@ void grid::ConvertToLibyt(int LocalGridID, int GlobalGridID, int ParentID, int l
     float *cooling_time_field = new float[grid_size];
 
     ComputeTemperatureField(temp_field);
-    ComputeCoolingTimeField(cooling_time_field);
+    ComputeCoolingTime(cooling_time_field);
 
     libyt_generated_derived_field.push_bach(temp_field);
     libyt_generated_derived_field.push_bach(cooling_time_field);

--- a/src/enzo/Grid_ConvertToLibyt.C
+++ b/src/enzo/Grid_ConvertToLibyt.C
@@ -123,5 +123,14 @@ void grid::ConvertToLibyt(int LocalGridID, int GlobalGridID, int ParentID, int l
     else {
         GridInfo.par_count_list[0] = 0;
     }
+
+    /* fill in active particle count */
+    std::vector<long> active_particle_count(EnabledActiveParticlesCount, 0);
+    for (int i = 0; i < NumberOfActiveParticles; i++) {
+        active_particle_count[(this->ActiveParticles)[i]->GetEnabledParticleID()]++;
+    }
+    for (int i = 0; i < EnabledActiveParticlesCount; i++) {
+        GridInfo.par_count_list[1 + i] = active_particle_count[i];
+    }
 }
 #endif

--- a/src/enzo/Grid_ConvertToLibyt.C
+++ b/src/enzo/Grid_ConvertToLibyt.C
@@ -89,8 +89,8 @@ void grid::ConvertToLibyt(int LocalGridID, int GlobalGridID, int ParentID, int l
     ComputeTemperatureField(temp_field);
     ComputeCoolingTime(cooling_time_field);
 
-    libyt_generated_derived_field.push_bach(temp_field);
-    libyt_generated_derived_field.push_bach(cooling_time_field);
+    libyt_generated_derived_field.push_back(temp_field);
+    libyt_generated_derived_field.push_back(cooling_time_field);
 
     int temp_field_i = (yt_param_yt*)param_yt->num_fields - 2;
     int cooling_time_field_i = (yt_param_yt*)param_yt->num_fields - 1;

--- a/src/enzo/Grid_ConvertToLibyt.C
+++ b/src/enzo/Grid_ConvertToLibyt.C
@@ -133,24 +133,26 @@ void grid::ConvertToLibyt(int LocalGridID, int GlobalGridID, int ParentID, int l
         GridInfo.par_count_list[1 + i] = active_particle_count[i]; // TODO: check why 1483, 1484 both have count 1
     }
 
-    /* fill in buffer
+    /* fill in buffer only if there is active particle, which is sum of active particle count > 0
      * ignore AccretionRate/AccretionRateTime/Accreted_angmom for now since they are not one dimensional */
-    for (int i = 0; i < EnabledActiveParticlesCount; i++) {
-        ActiveParticleType_info *ActiveParticleTypeToEvaluate = EnabledActiveParticles[i];
+    if (NumberOfActiveParticles > 0) {
+        for (int i = 0; i < EnabledActiveParticlesCount; i++) {
+            ActiveParticleType_info *ActiveParticleTypeToEvaluate = EnabledActiveParticles[i];
 
-        // the returned buffer ignores multi-dimensional array for now, it set them as nullptr.
-        std::vector<void*> par_attr_buffer = ActiveParticleTypeToEvaluate->GetParticleAttributes(
-                this->ActiveParticles, i, NumberOfActiveParticles, active_particle_count[i],
-                ActiveParticleTypeToEvaluate->particle_name
-                );
+            // the returned buffer ignores multi-dimensional array for now, it set them as nullptr.
+            std::vector<void*> par_attr_buffer = ActiveParticleTypeToEvaluate->GetParticleAttributes(
+                    this->ActiveParticles, i, NumberOfActiveParticles, active_particle_count[i],
+                    ActiveParticleTypeToEvaluate->particle_name
+                    );
 
-        for (int a = 0; a < par_attr_buffer.size(); a++) {
-            GridInfo.particle_data[1 + i][a].data_ptr = par_attr_buffer[a];
+            for (int a = 0; a < par_attr_buffer.size(); a++) {
+                GridInfo.particle_data[1 + i][a].data_ptr = par_attr_buffer[a];
+            }
+
+            // TODO: rename libyt_generated_derived_field
+            // free these pre-allocated buffer after libyt in situ analysis is done.
+            libyt_generated_derived_field.insert(libyt_generated_derived_field.end(), par_attr_buffer.begin(), par_attr_buffer.end());
         }
-
-        // TODO: rename libyt_generated_derived_field
-        // free these pre-allocated buffer at the very end.
-        libyt_generated_derived_field.insert(libyt_generated_derived_field.end(), par_attr_buffer.begin(), par_attr_buffer.end());
     }
 }
 #endif

--- a/src/enzo/Grid_ConvertToLibyt.C
+++ b/src/enzo/Grid_ConvertToLibyt.C
@@ -92,8 +92,8 @@ void grid::ConvertToLibyt(int LocalGridID, int GlobalGridID, int ParentID, int l
     libyt_generated_derived_field.push_back(temp_field);
     libyt_generated_derived_field.push_back(cooling_time_field);
 
-    int temp_field_i = (yt_param_yt*)param_yt->num_fields - 2;
-    int cooling_time_field_i = (yt_param_yt*)param_yt->num_fields - 1;
+    int temp_field_i = ((yt_param_yt*)param_yt)->num_fields - 2;
+    int cooling_time_field_i = ((yt_param_yt*)param_yt)->num_fields - 1;
 
     GridInfo.field_data[temp_field_i].data_ptr = temp_field;
     GridInfo.field_data[cooling_time_field_i].data_ptr = cooling_time_field;

--- a/src/enzo/Grid_ConvertToLibyt.C
+++ b/src/enzo/Grid_ConvertToLibyt.C
@@ -78,9 +78,25 @@ void grid::ConvertToLibyt(int LocalGridID, int GlobalGridID, int ParentID, int l
          *
          * */
         int libyt_field = libyt_field_lookup[field];
-        if (libyt_field == -1) continue;
+        if (libyt_field == -1) continue; // TODO: will this ever be -1?
         GridInfo.field_data[libyt_field].data_ptr = BaryonField[field];
     }
+
+    long grid_size = GridDimension[0] * GridDimension[1] * GridDimension[2];
+    float *temp_field = new float[grid_size];
+    float *cooling_time_field = new float[grid_size];
+
+    ComputeTemperatureField(temp_field);
+    ComputeCoolingTimeField(cooling_time_field);
+
+    libyt_generated_derived_field.push_bach(temp_field);
+    libyt_generated_derived_field.push_bach(cooling_time_field);
+
+    int temp_field_i = (yt_param_yt*)param_yt->num_fields - 2;
+    int cooling_time_field_i = (yt_param_yt*)param_yt->num_fields - 1;
+
+    GridInfo.field_data[temp_field_i].data_ptr = temp_field;
+    GridInfo.field_data[cooling_time_field_i].data_ptr = cooling_time_field;
 
     /* par_count_list can take multiple particle types */
     if (this->ReturnNumberOfParticles() > 0) {

--- a/src/enzo/InitializeLibytInterface_finderfunctions.inc
+++ b/src/enzo/InitializeLibytInterface_finderfunctions.inc
@@ -33,7 +33,7 @@ YT_SET_USERPARAM_INTEGER("ProblemType", 1, &ProblemType);
 YT_SET_USERPARAM_INTEGER("HydroMethod", 1, &HydroMethod);
 YT_SET_USERPARAM_NONINTEGER("huge_number", 1, &huge_number);
 YT_SET_USERPARAM_NONINTEGER("tiny_number", 1, &tiny_number);
-YT_SET_USERPARAM_NONINTEGER("Gamma", 1, &Gamma);
+YT_SET_USERPARAM_NONINTEGER("gamma", 1, &Gamma);
 YT_SET_USERPARAM_INTEGER("PressureFree", 1, &PressureFree);
 YT_SET_USERPARAM_INTEGER("QuantumPressure", 1, &QuantumPressure);
 YT_SET_USERPARAM_NONINTEGER("FDMMass", 1, &FDMMass);

--- a/src/enzo/ParticleAttributeHandler.h
+++ b/src/enzo/ParticleAttributeHandler.h
@@ -22,6 +22,9 @@
 #ifdef USE_MPI
 #include <mpi.h>
 #endif
+//#ifdef USE_LIBYT
+//#include "libyt.h"
+//#endif
 #include <hdf5.h>
 class ActiveParticleType;
 
@@ -34,6 +37,9 @@ class ParticleAttributeHandler
 #ifdef USE_MPI
     MPI_Datatype mpitype;
 #endif
+//#ifdef USE_LIBYT
+//    yt_dtype yttype;
+//#endif
     hid_t hdf5type;
     int element_size;
     int offset;
@@ -60,21 +66,33 @@ class Handler : public ParticleAttributeHandler
 #ifdef USE_MPI
             this->mpitype = IntDataType;
 #endif
+//#ifdef USE_LIBYT
+//            this->yttype = EYT_INT;
+//#endif
             this->hdf5type = HDF5_INT;
         } else if (typeid(Type) == typeid(float)) {
 #ifdef USE_MPI
             this->mpitype = FloatDataType;
 #endif
+//#ifdef USE_LIBYT
+//            this->yttype = EYT_BFLOAT;
+//#endif
             this->hdf5type = HDF5_REAL;
         } else if (typeid(Type) == typeid(double)) {
 #ifdef USE_MPI
             this->mpitype = MPI_DOUBLE;
 #endif
+//#ifdef USE_LIBYT
+//            this->yttype = YT_DOUBLE;
+//#endif
             this->hdf5type = HDF5_R8;
         } else if (typeid(Type) == typeid(FLOAT)) {
 #ifdef USE_MPI
             this->mpitype = FLOATDataType;
 #endif
+//#ifdef USE_LIBYT
+//            this->yttype = EYT_PFLOAT;
+//#endif
             this->hdf5type = HDF5_PREC;
         } else {
             ENZO_FAIL("Unrecognized data type");
@@ -118,21 +136,33 @@ class ArrayHandler : public ParticleAttributeHandler
 #ifdef USE_MPI
             this->mpitype = IntDataType;
 #endif
+//#ifdef USE_LIBYT
+//            this->yttype = EYT_INT;
+//#endif
             this->hdf5type = HDF5_INT;
         } else if (typeid(Type) == typeid(float)) {
 #ifdef USE_MPI
             this->mpitype = FloatDataType;
 #endif
+//#ifdef USE_LIBYT
+//            this->yttype = EYT_BFLOAT;
+//#endif
             this->hdf5type = HDF5_REAL;
         } else if (typeid(Type) == typeid(double)) {
 #ifdef USE_MPI
             this->mpitype = MPI_DOUBLE;
 #endif
+//#ifdef USE_LIBYT
+//            this->yttype = YT_DOUBLE;
+//#endif
             this->hdf5type = HDF5_R8;
         } else if (typeid(Type) == typeid(FLOAT)) {
 #ifdef USE_MPI
             this->mpitype = FLOATDataType;
 #endif
+//#ifdef USE_LIBYT
+//            this->yttype = EYT_PFLOAT;
+//#endif
             this->hdf5type = HDF5_PREC;
         } else {
             ENZO_FAIL("Unrecognized data type");

--- a/src/enzo/ParticleAttributeHandler.h
+++ b/src/enzo/ParticleAttributeHandler.h
@@ -22,9 +22,6 @@
 #ifdef USE_MPI
 #include <mpi.h>
 #endif
-//#ifdef USE_LIBYT
-//#include "libyt.h"
-//#endif
 #include <hdf5.h>
 class ActiveParticleType;
 
@@ -37,9 +34,6 @@ class ParticleAttributeHandler
 #ifdef USE_MPI
     MPI_Datatype mpitype;
 #endif
-//#ifdef USE_LIBYT
-//    yt_dtype yttype;
-//#endif
     hid_t hdf5type;
     int element_size;
     int offset;
@@ -66,33 +60,21 @@ class Handler : public ParticleAttributeHandler
 #ifdef USE_MPI
             this->mpitype = IntDataType;
 #endif
-//#ifdef USE_LIBYT
-//            this->yttype = EYT_INT;
-//#endif
             this->hdf5type = HDF5_INT;
         } else if (typeid(Type) == typeid(float)) {
 #ifdef USE_MPI
             this->mpitype = FloatDataType;
 #endif
-//#ifdef USE_LIBYT
-//            this->yttype = EYT_BFLOAT;
-//#endif
             this->hdf5type = HDF5_REAL;
         } else if (typeid(Type) == typeid(double)) {
 #ifdef USE_MPI
             this->mpitype = MPI_DOUBLE;
 #endif
-//#ifdef USE_LIBYT
-//            this->yttype = YT_DOUBLE;
-//#endif
             this->hdf5type = HDF5_R8;
         } else if (typeid(Type) == typeid(FLOAT)) {
 #ifdef USE_MPI
             this->mpitype = FLOATDataType;
 #endif
-//#ifdef USE_LIBYT
-//            this->yttype = EYT_PFLOAT;
-//#endif
             this->hdf5type = HDF5_PREC;
         } else {
             ENZO_FAIL("Unrecognized data type");
@@ -136,33 +118,21 @@ class ArrayHandler : public ParticleAttributeHandler
 #ifdef USE_MPI
             this->mpitype = IntDataType;
 #endif
-//#ifdef USE_LIBYT
-//            this->yttype = EYT_INT;
-//#endif
             this->hdf5type = HDF5_INT;
         } else if (typeid(Type) == typeid(float)) {
 #ifdef USE_MPI
             this->mpitype = FloatDataType;
 #endif
-//#ifdef USE_LIBYT
-//            this->yttype = EYT_BFLOAT;
-//#endif
             this->hdf5type = HDF5_REAL;
         } else if (typeid(Type) == typeid(double)) {
 #ifdef USE_MPI
             this->mpitype = MPI_DOUBLE;
 #endif
-//#ifdef USE_LIBYT
-//            this->yttype = YT_DOUBLE;
-//#endif
             this->hdf5type = HDF5_R8;
         } else if (typeid(Type) == typeid(FLOAT)) {
 #ifdef USE_MPI
             this->mpitype = FLOATDataType;
 #endif
-//#ifdef USE_LIBYT
-//            this->yttype = EYT_PFLOAT;
-//#endif
             this->hdf5type = HDF5_PREC;
         } else {
             ENZO_FAIL("Unrecognized data type");

--- a/src/enzo/global_data.h
+++ b/src/enzo/global_data.h
@@ -984,7 +984,7 @@ EXTERN PyObject *my_processor;
 EXTERN char libyt_script_name[512];
 EXTERN void *param_libyt;
 EXTERN void *param_yt;
-EXTERN std::vector<*void> libyt_generated_derived_field;
+EXTERN std::vector<void*> libyt_generated_derived_field;
 EXTERN int libyt_field_lookup[FieldUndefined];
 EXTERN int NumberOfLibytCalls;
 EXTERN int NumberOfLibytTopGridCalls;

--- a/src/enzo/global_data.h
+++ b/src/enzo/global_data.h
@@ -984,7 +984,7 @@ EXTERN PyObject *my_processor;
 EXTERN char libyt_script_name[512];
 EXTERN void *param_libyt;
 EXTERN void *param_yt;
-EXTERN std::vector<void*> libyt_generated_derived_field;
+EXTERN std::vector<void*> libyt_generated_data;
 EXTERN int libyt_field_lookup[FieldUndefined];
 EXTERN int NumberOfLibytCalls;
 EXTERN int NumberOfLibytTopGridCalls;

--- a/src/enzo/global_data.h
+++ b/src/enzo/global_data.h
@@ -980,9 +980,11 @@ EXTERN PyObject *my_processor;
 #endif
 
 #ifdef USE_LIBYT
+#include <vector>
 EXTERN char libyt_script_name[512];
 EXTERN void *param_libyt;
 EXTERN void *param_yt;
+EXTERN std::vector<*void> libyt_generated_derived_field;
 EXTERN int libyt_field_lookup[FieldUndefined];
 EXTERN int NumberOfLibytCalls;
 EXTERN int NumberOfLibytTopGridCalls;

--- a/src/enzo/macros_and_parameters.h
+++ b/src/enzo/macros_and_parameters.h
@@ -355,7 +355,7 @@ typedef long long int   HDF5_hid_t;
 #define PISYM "lld"
 #define ENPY_PINT NPY_LONG
 #ifdef USE_LIBYT
-#define EYT_PINT YT_LONG
+#define EYT_PINT YT_LONGLONG
 #endif
 #endif
 


### PR DESCRIPTION
## Fix bugs, Load Active Particles and Derived Fields

### Doc
- Fix the link.
- Explain the usage of `sm,pt2pt`.

### Bugs
- Change user-parameter `Gamma` to `gamma`, since enzo's yt frontend reads `ds.gamma`.
- Fix yt-parameter `velocity_unit`, `magnetic_unit`, `periodicity`.
- Map `EYT_PINT` to `YT_LONGLONG` when `-DCONFIG_PINT_8`. (Note that in this setting, MPI is mapped to `MPI_LONG_LONG_INT`.)

### Derived Fields
- Generate derived fields (`Temperature`, `Cooling_Time`) and assign them as enzo inline fields. This avoids looking up grid ID when using `libyt`'s generating data from C-function.

### Active Particles
- Load active particles to `libyt`.
- When mapping the particle attributes data type to yt datatype, we use the hdf5 data type as an indicator. This avoids including `libyt.h` in `ParticleAttributeHandler.h`. And because hdf5 is a mandatory dependency, using hdf5 data type to map to yt data type won't have any conflict.
- `GetParticleAttributeNames`, `GetParticleAttributes`, and `GetParticleAttributesHDF5DataType` are created in `ActiveParticleHelpers` namespace. They are used in libyt only. Since the active particle is created via a `register_ptype` function layer, adding them here will not alter the original behavior of the active particle. 
  - `GetParticleAttributes` allocates a new data buffer and calls `GetAttribute` to fill in the buffer. These buffers will be freed after libyt is done. Currently, we only get the attributes that have 1 dimension. (Notice that `GetAttribute` shifts the buffer pointer when returning.)