### PR TITLE
Support Dim 2/1 Field

### DIFF
--- a/doc/manual/source/user_guide/InSituPythonAnalysis.rst
+++ b/doc/manual/source/user_guide/InSituPythonAnalysis.rst
@@ -16,9 +16,9 @@ Below are links to the build and runtime requirements, which must be installed.
 We can compile ``libyt`` using different options based on our used cases, so that Enzo can have different in situ analysis feature when it links to ``libyt``.
 
 A brief description of each mode (option) is shown here. The options are for compiling ``libyt`` only, and they are mutually independent.
-Please follow the instructions in ``libyt`` documents:
+Please follow the instructions in ``libyt`` `how to install <https://libyt.readthedocs.io/en/latest/how-to-install/how-to-install.html#how-to-install>`__:
 
-* `libyt`_ (>=0.2.0, <1.0): a C shared library for in situ analysis.
+* `libyt`_ (>=0.3.0, <1.0): a C shared library for in situ analysis.
 
   * **Serial Mode** (``-DSERIAL_MODE=ON``): Compile ``libyt`` using GCC compiler.
 
@@ -36,9 +36,9 @@ Please follow the instructions in ``libyt`` documents:
 
   * `yt`_: An open-source, permissively-licensed python package for analyzing and visualizing volumetric data.
 
-  * `yt_libyt`_ (>=0.2.0, <1.0): ``libyt``'s yt frontend.
+  * `yt_libyt`_ (>=0.3.0, <1.0): ``libyt``'s yt frontend.
 
-  * `jupyter_libyt`_ (>=0.2.0, <1.0): A Jupyter Client plugin for connecting to libyt Jupyter kernel. This is only required in **jupyter kernel mode**.
+  * `jupyter_libyt`_ (>=0.1.0, <1.0): A Jupyter Client plugin for connecting to libyt Jupyter kernel. This is only required in **jupyter kernel mode**.
 
 .. _libyt: https://libyt.readthedocs.io/en/latest/
 
@@ -76,6 +76,10 @@ How to Configure
 
 General
 ^^^^^^^
+
+* **What kind of test problem will it work?**
+
+  It will work with all test problems with dimensionality 1, 2, and 3 field data or with dimensionality 3 particle data.
 
 * **How to change import Python file name?**
 

--- a/src/enzo/CallInSitulibyt.C
+++ b/src/enzo/CallInSitulibyt.C
@@ -173,6 +173,10 @@ int CallInSitulibyt(LevelHierarchyEntry *LevelArray[], TopGridData *MetaData,
     params->domain_dimensions[0] = MetaData->TopGridDims[0];
     params->domain_dimensions[1] = MetaData->TopGridDims[1];
     params->domain_dimensions[2] = MetaData->TopGridDims[2];
+	for (int d = 2; d > params->dimensionality - 1; d--) {
+		params->domain_dimensions[d] = 1;
+	}
+
     params->refine_by = RefineBy;
     params->index_offset = 1;
     params->num_grids = num_grids;
@@ -312,7 +316,7 @@ int CallInSitulibyt(LevelHierarchyEntry *LevelArray[], TopGridData *MetaData,
         field_list[libyt_field_i].field_name = DataLabel[i];
         field_list[libyt_field_i].field_type = "cell-centered";
         field_list[libyt_field_i].field_dtype = EYT_BFLOAT;
-        for (j = 0; j < 6; j++) {
+        for (j = 0; j < 2 * params->dimensionality; j++) {
             /*
              * It may be possible that in some cases, this global value is not
              * correct; however, it's pretty unlikely, and non-cell-centered
@@ -338,7 +342,7 @@ int CallInSitulibyt(LevelHierarchyEntry *LevelArray[], TopGridData *MetaData,
     field_list[libyt_field_i].field_name = "Temperature";
     field_list[libyt_field_i].field_type = "cell-centered";
     field_list[libyt_field_i].field_dtype = EYT_BFLOAT;
-    for (j = 0; j < 6; j++) {
+    for (j = 0; j < 2 * params->dimensionality; j++) {
         field_list[libyt_field_i].field_ghost_cell[j] = NumberOfGhostZones;
     }
     libyt_field_i = libyt_field_i + 1;
@@ -347,7 +351,7 @@ int CallInSitulibyt(LevelHierarchyEntry *LevelArray[], TopGridData *MetaData,
     field_list[libyt_field_i].field_type = "cell-centered";
     field_list[libyt_field_i].field_unit = "code_time";
     field_list[libyt_field_i].field_dtype = EYT_BFLOAT;
-    for (j = 0; j < 6; j++) {
+    for (j = 0; j < 2 * params->dimensionality; j++) {
         field_list[libyt_field_i].field_ghost_cell[j] = NumberOfGhostZones;
     }
 


### PR DESCRIPTION
- Support using dimension 2 and 1 field in `libyt`.
- `libyt` still only supports dimension 3 for particles. (Enzo dim 2/1 particle is not tested)